### PR TITLE
Fix errcheck lint error for viper.BindPFlags

### DIFF
--- a/cmd/gobgp/root.go
+++ b/cmd/gobgp/root.go
@@ -122,7 +122,7 @@ func newRootCmd() *cobra.Command {
 	viper.SetEnvPrefix("GOBGP")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
-	viper.BindPFlags(rootCmd.PersistentFlags())
+	_ = viper.BindPFlags(rootCmd.PersistentFlags())
 
 	globalCmd := newGlobalCmd()
 	neighborCmd := newNeighborCmd()


### PR DESCRIPTION
Explicitly ignore the return value to satisfy the errcheck linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)